### PR TITLE
Restore WildFly Camel Subsystem support

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1443,6 +1443,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
         </dependency>

--- a/feature-pack/src/license/full-feature-pack-licenses.xml
+++ b/feature-pack/src/license/full-feature-pack-licenses.xml
@@ -4114,6 +4114,17 @@
       </licenses>
     </dependency>
     <dependency>
+      <groupId>org.jdom</groupId>
+      <artifactId>jdom</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </dependency>
+    <dependency>
       <groupId>org.jgroups</groupId>
       <artifactId>jgroups</artifactId>
       <licenses>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jdom/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jdom/main/module.xml
@@ -20,22 +20,20 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.5" name="org.jaxen">
+<module xmlns="urn:jboss:module:1.5" name="org.jdom">
     <properties>
-        <property name="jboss.api" value="private"/>
+        <!-- WFLY-11326. Remove this in WildFly 16.
+             It is not used by WildFly. -->
+        <property name="jboss.api" value="deprecated"/>
     </properties>
 
     <dependencies>
-        <module name="nu.xom"/>
-        <module name="org.dom4j"/>
-        <!-- jaxen's uses of jdom are not actually used in WildFly
-              See WFLY-11325 / WFLY-11326 -->
-        <module name="org.jdom" optional="true"/>
+        <module name="org.jaxen"/>
         <module name="javax.api"/>
     </dependencies>
 
     <resources>
-        <artifact name="${jaxen:jaxen}"/>
+        <artifact name="${org.jdom:jdom}"/>
     </resources>
 
 </module>

--- a/galleon-pack/pom.xml
+++ b/galleon-pack/pom.xml
@@ -1677,6 +1677,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jdom</groupId>
+            <artifactId>jdom</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -193,13 +193,13 @@
         <version.checkstyle>8.5</version.checkstyle>
         <version.help.plugin>2.2</version.help.plugin>
         <version.jacoco.plugin>0.7.9</version.jacoco.plugin>
-        <version.org.jboss.galleon>3.0.0.Final</version.org.jboss.galleon>
+        <version.org.jboss.galleon>4.1.1.Final</version.org.jboss.galleon>
 
         <version.org.wildfly.build-tools>1.2.10.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.7.Final</version.org.wildfly.checkstyle-config>
 
         <version.org.wildfly.component-matrix-plugin>1.0.2.Final</version.org.wildfly.component-matrix-plugin>
-        <version.org.wildfly.galleon-plugins>3.0.0.Final</version.org.wildfly.galleon-plugins>
+        <version.org.wildfly.galleon-plugins>4.0.4.Final</version.org.wildfly.galleon-plugins>
         <version.org.wildfly.maven.plugins>1.0.1</version.org.wildfly.maven.plugins>
         <version.org.wildfly.plugin>1.2.1.Final</version.org.wildfly.plugin>
         <!-- Non-default maven plugin versions and configuration -->

--- a/pom.xml
+++ b/pom.xml
@@ -375,6 +375,7 @@
         <version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
         <version.org.jboss.ws.spi>3.2.3.Final</version.org.jboss.ws.spi>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.6.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
+        <version.org.jdom>1.1.3</version.org.jdom>
         <version.org.jgroups>4.0.15.Final</version.org.jgroups>
         <version.org.jgroups.azure>1.2.0.Final</version.org.jgroups.azure>
         <version.org.jgroups.kubernetes>1.0.6.Final</version.org.jgroups.kubernetes>
@@ -1638,6 +1639,10 @@
                     <exclusion>
                         <groupId>jaxen</groupId>
                         <artifactId>jaxen</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jdom</groupId>
+                        <artifactId>jdom</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>maven-plugins</groupId>
@@ -6113,6 +6118,12 @@
                         <artifactId>netty-transport</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jdom</groupId>
+                <artifactId>jdom</artifactId>
+                <version>${version.org.jdom}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Fix for wildfly-extras/wildfly-camel#2921, Upgrade galleon and galleon-plugins

Also reverted the commit removing jdom because it's actually needed.