### PR TITLE
Supress CVE-2016-8739

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -180,5 +180,13 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.jboss\.resteasy/resteasy\-jaxrs@.*$</packageUrl>
         <vulnerabilityName>CVE-2016-9606</vulnerabilityName>
+    </suppress>
+    <!-- WildFly implement JAX-RS using Resteasy, not CXF. Therefore it's not affected. -->
+    <suppress>
+        <notes><![CDATA[
+        file name: cxf-xjc-ts-3.0.5.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.cxf\.xjcplugins/cxf\-xjc\-ts@.*$</packageUrl>
+        <cve>CVE-2016-8739</cve>
      </suppress>
 </suppressions>


### PR DESCRIPTION
WildFly implement JAX-RS using Resteasy, not CXF. Therefore it's not affected.