### PR TITLE
Add missing suppression for CVE-2018-1000632

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -188,5 +188,13 @@
         ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.apache\.cxf\.xjcplugins/cxf\-xjc\-ts@.*$</packageUrl>
         <cve>CVE-2016-8739</cve>
+    </suppress>
+    <!--  This CVE was fixed in e4b0848f68ea3bb45b067540ccaddc7973c7ac57, vulnerable dom4j-1.6.1.jar is now only a test dependency and is not present in distrubution.-->
+    <suppress>
+        <notes><![CDATA[
+        file name: dom4j-1.6.1.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/dom4j/dom4j@.*$</packageUrl>
+        <cve>CVE-2018-1000632</cve>
      </suppress>
 </suppressions>


### PR DESCRIPTION
Add missing suppression for CVE-2018-1000632

This CVE was fixed in e4b0848f68ea3bb45b067540ccaddc7973c7ac57,  vulnerable dom4j-1.6.1.jar  is now only a test dependency and is not present in distrubution.