### PR TITLE
[COM_WILDFLY-196] Add missing suppresion for CVE-2014-3530

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -189,4 +189,12 @@
         <packageUrl regex="true">^pkg:maven/org\.apache\.cxf\.xjcplugins/cxf\-xjc\-ts@.*$</packageUrl>
         <cve>CVE-2016-8739</cve>
      </suppress>
+     <!--  This issue was fixed in this commit https://github.com/picketlink/picketlink/commit/8c78668e4f08cf3c4ed14d8a36d402dcf02cb057#diff-424514e417d84d8d07c9ff3197048739, and PicketLink 2.5.5.SP12-redhat-00005 has this patch. -->
+     <suppress>
+        <notes><![CDATA[
+        file name: picketlink-common-2.5.5.SP12-redhat-00005.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.picketlink/picketlink\-common@.*$</packageUrl>
+        <vulnerabilityName>CVE-2014-3530</vulnerabilityName>
+     </suppress>
 </suppressions>


### PR DESCRIPTION
This issue was fixed in [this](https://github.com/picketlink/picketlink/commit/8c78668e4f08cf3c4ed14d8a36d402dcf02cb057#diff-424514e417d84d8d07c9ff3197048739) commit, and PicketLink 2.5.5.SP12-redhat-00005 has this patch.

This was fixed as a side effect of PicketLink version upgrade in 8d2ea43a6cb2249856a28a4c3e6c0a65b8cf401b.