### PR TITLE
[COM_WILDFLY-188,COM_WILDFLY-187] Fix CVE-2017-15089, CVE-2016-0750

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -205,4 +205,28 @@
         <packageUrl regex="true">^pkg:maven/org\.picketlink/picketlink\-common@.*$</packageUrl>
         <vulnerabilityName>CVE-2014-3530</vulnerabilityName>
      </suppress>
+    <!-- According to https://bugzilla.redhat.com/show_bug.cgi?id=1503610 CVE-2017-15089 was fixed in Infinispan 8.2.9.Final -->
+     <suppress>
+        <notes><![CDATA[
+        file name: hibernate-infinispan-4.2.13.Final.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate\-infinispan@.*$</packageUrl>
+        <cve>CVE-2017-15089</cve>
+     </suppress>
+     <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.infinispan/infinispan\-.*@.*$</packageUrl>
+        <cve>CVE-2017-15089</cve>
+     </suppress>
+    <!-- According to https://bugzilla.redhat.com/show_bug.cgi?id=1300443 and https://issues.redhat.com/browse/ISPN-7781 CVE-2016-0750 was fixed in Infinispan 8.2.9.Final -->
+     <suppress>
+        <notes><![CDATA[
+        file name: hibernate-infinispan-4.3.10.Final.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.hibernate/hibernate\-infinispan@.*$</packageUrl>
+        <cve>CVE-2016-0750</cve>
+     </suppress>
+     <suppress>
+        <packageUrl regex="true">^pkg:maven/org\.infinispan/infinispan\-.*@.*$</packageUrl>
+        <cve>CVE-2016-0750</cve>
+     </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.search>5.5.4.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
-        <version.org.infinispan>8.2.4.Final</version.org.infinispan>
+        <version.org.infinispan>8.2.9.Final-redhat-1</version.org.infinispan>
         <version.org.jasypt>1.9.2</version.org.jasypt>
         <version.org.javassist>3.22.0-GA</version.org.javassist>
         <version.org.jberet>1.2.1.Final</version.org.jberet>


### PR DESCRIPTION
According to https://bugzilla.redhat.com/show_bug.cgi?id=1503610 CVE-2017-15089 was fixed in Infinispan 8.2.9.Final
According to https://bugzilla.redhat.com/show_bug.cgi?id=1300443 and https://issues.redhat.com/browse/ISPN-7781 CVE-2016-0750 was fixed in Infinispan 8.2.9.Final