### PR TITLE
Fix security issue CVE-2020-9546 by updating jackson-databind to 2.9.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
         <version.com.fasterxml.classmate>1.3.4</version.com.fasterxml.classmate>
         <version.com.fasterxml.jackson>2.9.8</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson-databind>2.9.10.3</version.com.fasterxml.jackson-databind>
+        <version.com.fasterxml.jackson-databind>2.9.10.4</version.com.fasterxml.jackson-databind>
         <version.com.github.relaxng>2011.1</version.com.github.relaxng>
         <version.com.google.guava>25.0-jre</version.com.google.guava>
         <version.com.h2database>1.3.173</version.com.h2database>


### PR DESCRIPTION
DO NOT MERGE YET. jackson-databind 2.9.10.4 is NOT YET RELEASED.