### PR TITLE
PJFCB-1438 CVE-2020-36518 WildFly 21, jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -260,7 +260,8 @@
         <cve>CVE-2018-1337</cve>
     </suppress>
 
-    <!-- [wildfly] WildFly PSI-21.x ships with jackson-databind 2.10.5.1 -->
+    <!-- [wildfly] WildFly PSI-21.x ships with jackson-databind 2.12.6.1 -->
+    <!-- [CVE-2020-36518] This vulnerability affects com.fasterxml.jackson.core:jackson-databind not org.codehaus.jackson:jackson-xc artifact. Issue has been fixed in 2.13.2.1 and 2.12.6.1 versions. (https://github.com/advisories/GHSA-57j2-w4cx-62h2) -->
     <suppress>
         <notes><![CDATA[
    file name: jackson-xc-1.9.13.redhat-00007.jar
@@ -268,8 +269,8 @@
         <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-.*@.*$</packageUrl>
         <cve>CVE-2018-14718</cve>
         <cve>CVE-2018-7489</cve>
+        <cve>CVE-2020-36518</cve>
     </suppress>
-
     <!-- [wildfly-core] The vulnerability applies to io.undertow package, undertow-server from org.wildfly.security.elytron-web package is a different module -->
     <suppress>
         <notes><![CDATA[

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,8 @@
         <version.antlr>2.7.7</version.antlr>
         <version.com.beust>1.78</version.com.beust>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.10.5</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.12.6</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>2.12.6.1</version.com.fasterxml.jackson.databind>
         <version.com.github.ben-manes.caffeine>2.8.5</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.btf>1.2</version.com.github.fge.btf>
         <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>
@@ -1505,7 +1506,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${version.com.fasterxml.jackson}.1</version>
+                <version>${version.com.fasterxml.jackson.databind}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
Build with -DallTests and OWASP report for this branch:

https://jenkins3.comdev.psi.de/job/WCC/view/03.%20WildFly%2021%20Build/job/wf21-build-wildfly/261/

https://jenkins3.comdev.psi.de/job/WCC/view/02.%20OWASP%20Reports/job/wf21-owasp-wildfly/WildFly_2021_20OWASP_20Report/