### PR TITLE
PJFCB-1519 CVE-2020-36518 WildFly 15, jackson-databind before 2.13.0 allows a Java StackOverflow exception and denial of service via a large depth of nested objects.

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -10,7 +10,8 @@
         <cve>CVE-2021-26296</cve>
     </suppress>
 
-    <!-- [wildfly] WildFly 15.0.1-10-PSI ships with jackson-databind 2.10.5.1 -->
+    <!-- [wildfly] WildFly 15.0.1-10-PSI ships with jackson-databind 2.12.6.1 -->
+    <!-- [CVE-2020-36518] This vulnerability affects com.fasterxml.jackson.core:jackson-databind not org.codehaus.jackson:jackson-xc artifact. Issue has been fixed in 2.13.2.1 and 2.12.6.1 versions. (https://github.com/advisories/GHSA-57j2-w4cx-62h2) -->
     <suppress>
         <notes><![CDATA[
    file name: jackson-xc-1.9.14.jdk17-redhat-00001.jar
@@ -19,6 +20,7 @@
         <packageUrl regex="true">^pkg:maven/org\.codehaus\.jackson/jackson\-.*@.*$</packageUrl>
         <cve>CVE-2018-14718</cve>
         <cve>CVE-2018-7489</cve>
+        <cve>CVE-2020-36518</cve>
     </suppress>
 
     <!-- [wildfly] CVE-2020-10718 Fixed by applying https://github.com/wildfly/wildfly-core/pull/4293 (see https://issues.redhat.com/browse/WFCORE-4956?jql=text%20~%20%22CVE-2020-10718%22) -->

--- a/pom.xml
+++ b/pom.xml
@@ -223,8 +223,8 @@
          -->
         <version.antlr>2.7.7</version.antlr>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.10.5</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.core.jackson-databind>2.10.5.1</version.com.fasterxml.jackson.core.jackson-databind>
+        <version.com.fasterxml.jackson>2.12.6</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.core.jackson-databind>2.12.6.1</version.com.fasterxml.jackson.core.jackson-databind>
         <version.com.github.ben-manes.caffeine>2.6.2</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.jackson-coreutils>1.0</version.com.github.fge.jackson-coreutils>
         <version.com.github.fge.json-patch>1.3</version.com.github.fge.json-patch>


### PR DESCRIPTION
Build with -DallTests and OWASP report for this branch:

https://jenkins3.comdev.psi.de/job/WCC/view/05.%20WildFly%2015%20Build/job/wf15-build-wildfly/284/

https://jenkins3.comdev.psi.de/job/WCC/view/02.%20OWASP%20Reports/job/wf15-owasp-wildfly/WildFly_2015_20OWASP_20Report/