### PR TITLE
PJFCB-2439 suppression for CVE 2022 2053

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -700,4 +700,31 @@
         <cve>CVE-2022-37422</cve>
     </suppress>
 
+    <!--undertow 2.2.19.Final fixed CVE-2022-2053  based on https://bugzilla.redhat.com/show_bug.cgi?id=2095862-->
+    <suppress>
+        <notes><![CDATA[
+   file name: undertow-core-2.2.19.Final.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.undertow/undertow\-core@.*$</packageUrl>
+        <vulnerabilityName>CVE-2022-2053</vulnerabilityName>
+    </suppress>
+    <!-- undertow server servlet uses undertow-core, so it also has fixed CVE-2022-2053 when using undertow-core-2.2.19
+    .Final-->
+    <suppress>
+        <notes><![CDATA[
+   file name: undertow-server-servlet-2.0.0.Beta1.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.wildfly\.security\.elytron\-web/undertow\-server\-servlet@.*$
+        </packageUrl>
+        <cve>CVE-2022-2053</cve>
+    </suppress>
+    <!-- undertow server uses undertow-core, so it also has fixed CVE-2022-2053 when using undertow-core-2.2.19.Final-->
+    <suppress>
+        <notes><![CDATA[
+   file name: undertow-server-1.10.1.Final.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.wildfly\.security\.elytron\-web/undertow\-server@.*$</packageUrl>
+        <cve>CVE-2022-2053</cve>
+    </suppress>
+
 </suppressions>


### PR DESCRIPTION
undertow 2.2.19.Final fixed CVE-2022-2053  based on https://bugzilla.redhat.com/show_bug.cgi?id=2095862
undertow server uses undertow-core, so it also has fixed CVE-2022-2053 when using undertow-core-2.2.19.Final
undertow server servlet uses undertow-core, so it also has fixed CVE-2022-2053 when using undertow-core-2.2.19.Final
