### PR TITLE
PJFCB-2812 CVE-2022-42004  WildFly 21 upgrade FasterXML jackson and jackson.databind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,8 +255,8 @@
         <version.antlr>2.7.7</version.antlr>
         <version.com.beust>1.78</version.com.beust>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.12.6</version.com.fasterxml.jackson>
-        <version.com.fasterxml.jackson.databind>2.12.6.1</version.com.fasterxml.jackson.databind>
+        <version.com.fasterxml.jackson>2.13.4</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson.databind>2.13.4.1</version.com.fasterxml.jackson.databind>
         <version.com.github.ben-manes.caffeine>2.8.5</version.com.github.ben-manes.caffeine>
         <version.com.github.fge.btf>1.2</version.com.github.fge.btf>
         <version.com.github.fge.jackson-coreutils>1.8</version.com.github.fge.jackson-coreutils>


### PR DESCRIPTION
 upgrade FasterXML jackson and jackson.databind version to 2.13.4 and 2.13.4.1 respectively