### PR TITLE
PJFCB-2689 CVE-2022-1278 WildFly 21 - Don't export traces by default

### DIFF
--- a/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracerAttributes.java
+++ b/microprofile/opentracing-extension/src/main/java/org/wildfly/extension/microprofile/opentracing/TracerAttributes.java
@@ -64,7 +64,6 @@ public class TracerAttributes {
 
     public static final SimpleAttributeDefinition SENDER_BINDING = SimpleAttributeDefinitionBuilder.create(TracerConfigurationConstants.SENDER_AGENT_BINDING, ModelType.STRING, true)
             .setAttributeGroup("sender-configuration")
-            .setAllowExpression(true)
             .setCapabilityReference(OUTBOUND_SOCKET_BINDING_CAPABILITY_NAME)
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
             .setRestartAllServices()


### PR DESCRIPTION
[WFLY-16238] Don't export traces by default
Fix based on https://github.com/wildfly/wildfly/pull/16082