### PR TITLE
PJFCB-12077 [HIGH] CVE-2024-43709 WildFly 31, An allocation of resour…

### DIFF
--- a/owasp-suppression.xml
+++ b/owasp-suppression.xml
@@ -350,5 +350,13 @@
         <packageUrl regex="true">^pkg:maven/org\.elasticsearch\.client/elasticsearch-rest-client@8\.11\.1$</packageUrl>
         <cve>CVE-2024-43709</cve>
     </suppress>
+    <!-- CVE in elasticsearch.jar not in elasticsearch-rest-client-sniffer -->
+    <suppress>
+        <notes><![CDATA[
+   file name: elasticsearch-rest-client-sniffer-8.11.1.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.elasticsearch\.client/elasticsearch-rest-client-sniffer@8\.11\.1$</packageUrl>
+        <cve>CVE-2024-43709</cve>
+    </suppress>
     <!-- ___End of Wildfly-dist suppressions___ -->
 </suppressions>


### PR DESCRIPTION
…ces without limits or throttling in Elasticsearch can lead to an OutOfMemoryError exception resulting in a crash via a specially crafted query using an SQL function - suppress sniffer

Thanks for submitting your Pull Request!

Please delete this text, and add a link to the Jira issue solved by this PR.

If this PR is not for the 'main' branch you must add a link to the equivalent change in 'main'.

Remember to use the Jira issue ID in the PR title and any commits.
