### PR TITLE
PJFCB-12119 [HIGH] CVE-2025-24970 WildFly 31, ### Impact When a speci…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
         <version.io.agroal>1.16</version.io.agroal>
         <version.io.grpc>1.38.1</version.io.grpc>
         <version.io.jaegertracing>1.6.0</version.io.jaegertracing>
-        <version.io.netty>4.1.100.Final</version.io.netty>
+        <version.io.netty>4.1.118.Final</version.io.netty>
         <version.io.opentelemetry.opentelemetry>1.9.1</version.io.opentelemetry.opentelemetry>
         <version.io.opentracing>0.33.0</version.io.opentracing>
         <version.io.opentracing.concurrent>0.4.0</version.io.opentracing.concurrent>


### PR DESCRIPTION
…al crafted packet is received via SslHandler it doesn't correctly handle validation of such a packet in all cases which can lead to a native crash -update netty to 4.1.118.Final

Thanks for submitting your Pull Request!

Please delete this text, and add a link to the Jira issue solved by this PR.

If this PR is not for the 'main' branch you must add a link to the equivalent change in 'main'.

Remember to use the Jira issue ID in the PR title and any commits.
