### PR TITLE
PJFCB-12457 Fix failing integration tests of WildFly 36 on PSI environment

### DIFF
--- a/dist/assembly.xml
+++ b/dist/assembly.xml
@@ -21,22 +21,6 @@
             </includes>
             <excludes>
                 <exclude>${server.output.dir.prefix}-${server.output.dir.version}/welcome-content/**</exclude>
-                <exclude>${server.output.dir.prefix}-${server.output.dir.version}/standalone/data/**</exclude>
-                <exclude>${server.output.dir.prefix}-${server.output.dir.version}/standalone/log/**</exclude>
-                <exclude>${server.output.dir.prefix}-${server.output.dir.version}/standalone/tmp/**</exclude>
-                <exclude>
-                    ${server.output.dir.prefix}-${server.output.dir.version}/standalone/configuration/standalone_xml_history/**
-                </exclude>
-                <exclude>${server.output.dir.prefix}-${server.output.dir.version}/domain/data/**</exclude>
-                <exclude>${server.output.dir.prefix}-${server.output.dir.version}/domain/log/**</exclude>
-                <exclude>${server.output.dir.prefix}-${server.output.dir.version}/domain/servers/**</exclude>
-                <exclude>${server.output.dir.prefix}-${server.output.dir.version}/domain/tmp/**</exclude>
-                <exclude>
-                    ${server.output.dir.prefix}-${server.output.dir.version}/domain/configuration/domain_xml_history/**
-                </exclude>
-                <exclude>
-                    ${server.output.dir.prefix}-${server.output.dir.version}/domain/configuration/host_xml_history/**
-                </exclude>
                 <exclude>
                     ${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/jboss/as/jacorb/**
                 </exclude>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -222,6 +222,9 @@
                     <value>true</value>
                 </property>
             </activation>
+            <properties>
+                <community-dist-backup-archive>community-dist-backup.zip</community-dist-backup-archive>
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -255,6 +258,42 @@
                                     <fpGroupId>${full.maven.groupId}</fpGroupId>
                                     <fpArtifactId>wildfly-galleon-pack</fpArtifactId>
                                     <fpVersion>${full.maven.version}</fpVersion>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <!-- Backups community distribution directory before introducing PSI hardening -->
+                            <execution>
+                                <id>backup-community-distribution</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <zip destfile="${project.build.directory}/${community-dist-backup-archive}"
+                                             basedir="${project.build.directory}/${project.build.finalName}"/>
+                                    </target>
+                                </configuration>
+                            </execution>
+                            <!-- Restores community distribution directory (without PSI hardening) after package is prepared,
+                                 so that integration tests comparing distribution folder contents are passing -->
+                            <execution>
+                                <id>restore-community-distribution</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <delete dir="${project.build.directory}/${project.build.finalName}"/>
+                                        <unzip src="${project.build.directory}/${community-dist-backup-archive}"
+                                               dest="${project.build.directory}/${project.build.finalName}"/>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>
@@ -619,6 +658,38 @@
                                     <systemProperties>
                                         <config>standalone-bdew.xml</config>
                                     </systemProperties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>post-hardening-cleanup</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                                <configuration>
+                                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>${project.build.directory}/${project.build.finalName}</directory>
+                                            <includes>
+                                                <include>standalone/data/**</include>
+                                                <include>standalone/log/**</include>
+                                                <include>standalone/tmp/**</include>
+                                                <include>standalone/configuration/standalone_xml_history/**</include>
+                                                <include>domain/data/**</include>
+                                                <include>domain/log/**</include>
+                                                <include>domain/servers/**</include>
+                                                <include>domain/tmp/**</include>
+                                                <include>domain/configuration/domain_xml_history/**</include>
+                                                <include>domain/configuration/host_xml_history/**</include>
+                                            </includes>
+                                        </fileset>
+                                    </filesets>
                                 </configuration>
                             </execution>
                         </executions>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -110,8 +110,9 @@
         <finalName>${server.output.dir.prefix}-${server.output.dir.version}</finalName>
         <plugins>
             <plugin>
-                <groupId>org.jboss.galleon</groupId>
-                <artifactId>galleon-maven-plugin</artifactId>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>${version.org.wildfly.plugin}</version>
                 <executions>
                     <execution>
                         <id>server-provisioning</id>
@@ -120,13 +121,24 @@
                         </goals>
                         <phase>compile</phase>
                         <configuration>
-                            <install-dir>${basedir}/target/${project.build.finalName}</install-dir>
-                            <record-state>true</record-state>
-                            <log-time>${galleon.log.time}</log-time>
-                            <offline>${galleon.offline}</offline>
-                            <plugin-options>
+                            <provisioningDir>${project.build.directory}/${project.build.finalName}</provisioningDir>
+                            <recordProvisioningState>true</recordProvisioningState>
+                            <log-provisioning-time>${galleon.log.time}</log-provisioning-time>
+                            <offline-provisioning>${galleon.offline}</offline-provisioning>
+                            <overwrite-provisioned-server>true</overwrite-provisioned-server>
+                            <galleon-options>
                                 <jboss-fork-embedded>${galleon.fork.embedded}</jboss-fork-embedded>
-                            </plugin-options>
+                            </galleon-options>
+                            <channels>
+                                <channel>
+                                    <name>wildfly</name>
+                                    <manifest>
+                                        <groupId>${channels.maven.groupId}</groupId>
+                                        <artifactId>wildfly</artifactId>
+                                        <version>${full.maven.version}</version>
+                                    </manifest>
+                                </channel>
+                            </channels>
                             <feature-packs>
                                 <feature-pack>
                                     <transitive>true</transitive>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -365,7 +365,7 @@
                     <plugin>
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
-                        <version>2.0.2.Final</version>
+                        <version>${version.org.wildfly.plugin}</version>
                         <configuration>
                             <jboss-home>${basedir}/target/${project.build.finalName}</jboss-home>
                             <offline>true</offline>

--- a/dist/src/verifier/verifications.xml
+++ b/dist/src/verifier/verifications.xml
@@ -35,6 +35,18 @@
       <exists>true</exists>
     </file>
     <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-ee-galleon-pack-unstable-api-annotation-index.zip</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/wildfly-ee-galleon-pack-unstable-api-annotation-index.zip</location>
+      <exists>false</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/modules/system/layers/base/org/wildfly/_internal/unstable-api-annotation-index/main/content/wildfly-galleon-pack-unstable-api-annotation-index.zip</location>
+      <exists>true</exists>
+    </file>
+    <file>
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/wildfly-galleon-pack-unstable-api-annotation-index.zip</location>
       <exists>false</exists>
     </file>
@@ -70,5 +82,23 @@
       <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.galleon/history</location>
       <exists>false</exists>
     </file>
+    <!-- start of (#12) -->
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/installer-channels.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/manifest.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/manifest_version.yaml</location>
+      <exists>true</exists>
+    </file>
+    <file>
+      <location>target/${server.output.dir.prefix}-${server.output.dir.version}/.installation/provisioning_record.xml</location>
+      <exists>true</exists>
+    </file>
+    <!-- end of (#12) -->
   </files>
 </verifications>

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
@@ -100,7 +100,7 @@ public class FaultToleranceOpenTelemetryIntegrationTestCase {
                     .findFirst();
             Assert.assertTrue(prometheusMetric.isPresent());
             Assert.assertEquals(0, Integer.parseInt(prometheusMetric.get().getValue()), 0);
-        }, Duration.ofSeconds(70)); // n.b. this in ~2% of cases needs slightly more time on our CI given the asynchronicity
+        }, Duration.ofSeconds(120)); // n.b. this in ~2% of cases needs slightly more time on our CI given the asynchronicity
     }
 
 }

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/faulttolerance/opentelemetry/FaultToleranceOpenTelemetryIntegrationTestCase.java
@@ -29,7 +29,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.Ignore;
 import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.FaultToleranceMicrometerIntegrationTestCase;
 import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deployment.FaultTolerantApplication;
 
@@ -43,7 +42,6 @@ import org.wildfly.test.integration.microprofile.faulttolerance.micrometer.deplo
 @RunWith(Arquillian.class)
 @RunAsClient
 @DockerRequired
-@Ignore
 // This test case does not use Micrometer *but* we enable it to verify CompoundMetricsProvider functionality in WF
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class, MicrometerSetupTask.class})
 public class FaultToleranceOpenTelemetryIntegrationTestCase {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/KeystoreUtil.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/KeystoreUtil.java
@@ -5,6 +5,7 @@
 
 package org.wildfly.test.integration.microprofile.reactive;
 
+import com.google.common.net.InetAddresses;
 import org.jboss.logging.Logger;
 
 import java.io.BufferedReader;
@@ -20,6 +21,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class KeystoreUtil {
     private static final Logger log = Logger.getLogger(KeystoreUtil.class.getSimpleName());
@@ -42,6 +44,10 @@ public class KeystoreUtil {
     public static final String CLIENT_TRUSTSTORE_PWD = "clientts";
 
     public static void createKeystores() throws IOException {
+        createKeystores("localhost","127.0.0.1");
+    }
+
+    public static void createKeystores(String... subjectAlternativeNames) throws IOException {
         Files.createDirectories(KEY_STORE_DIRECTORY_PATH);
 
         //keytool -genkeypair -alias localhost -keyalg RSA -keysize 2048 -storetype PKCS12 -keystore server.keystore.p12 -validity 3650  -ext SAN=DNS:localhost,IP:127.0.0.1
@@ -56,7 +62,7 @@ public class KeystoreUtil {
         createKeyStoreWithCertificateCommand.addAll(
                 List.of("-dname", "CN=localhost, OU=Unknown, O=Unknown, L=Unknown, ST=Unknown, C=Unknown"));
         createKeyStoreWithCertificateCommand.addAll(List.of("-validity", "3650"));
-        createKeyStoreWithCertificateCommand.addAll(List.of("-ext", "SAN=DNS:localhost,IP:127.0.0.1"));
+        createKeyStoreWithCertificateCommand.addAll(List.of("-ext", generateSubjectAlternativeNameExtension(subjectAlternativeNames)));
         runKeytoolCommand(createKeyStoreWithCertificateCommand);
 
         Files.createFile(SERVER_KEYSTORE_CREDENTIALS_PATH);
@@ -132,5 +138,17 @@ public class KeystoreUtil {
                 return super.postVisitDirectory(dir, exc);
             }
         });
+    }
+
+    private static String generateSubjectAlternativeNameExtension(String... subjectAlternativeNames) {
+        String entries = Stream.of(subjectAlternativeNames)
+                .map(KeystoreUtil::mapToSubjectAlternativeNameEntry)
+                .collect(Collectors.joining(","));
+        return "SAN=" + entries;
+    }
+
+    private static String mapToSubjectAlternativeNameEntry(String subjectAlternativeName) {
+        String prefix = InetAddresses.isInetAddress(subjectAlternativeName) ? "IP:" : "DNS:";
+        return prefix + subjectAlternativeName;
     }
 }

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/RunArtemisAmqpSetupTask.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/RunArtemisAmqpSetupTask.java
@@ -21,6 +21,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -41,6 +42,7 @@ public class RunArtemisAmqpSetupTask implements ServerSetupTask {
     private volatile String brokerXml = "messaging/amqp/broker.xml";
 
     private static final int AMQP_PORT = 5672;
+    private static final PathElement AMQP_HOST_PATH = PathElement.pathElement(SYSTEM_PROPERTY, "calculated.amqp.host");
     private static final PathElement AMQP_PORT_PATH = PathElement.pathElement(SYSTEM_PROPERTY, "calculated.amqp.port");
 
     public RunArtemisAmqpSetupTask() {
@@ -76,7 +78,7 @@ public class RunArtemisAmqpSetupTask implements ServerSetupTask {
                     "/home/jboss/config/broker.xml"
             );
             if (copyKeystore) {
-                KeystoreUtil.createKeystores();
+                KeystoreUtil.createKeystores(DockerClientFactory.instance().dockerHostIpAddress());
                 // Copy the keystore files to the expected container location
                 // The subclass should have configured the keystore in the broker.xml
                 container.withCopyFileToContainer(
@@ -91,6 +93,12 @@ public class RunArtemisAmqpSetupTask implements ServerSetupTask {
             int amqpPort = container.getMappedPort(AMQP_PORT);
             ModelNode op = Util.createAddOperation(PathAddress.pathAddress(AMQP_PORT_PATH), Map.of(VALUE, new ModelNode(amqpPort)));
             ModelNode result =  managementClient.getControllerClient().execute(op);
+            ModelTestUtils.checkOutcome(result);
+
+            // Set the calculated host as a property in the model
+            String amqpHost = container.getHost();
+            op = Util.createAddOperation(PathAddress.pathAddress(AMQP_HOST_PATH), Map.of(VALUE, new ModelNode(amqpHost)));
+            result =  managementClient.getControllerClient().execute(op);
             ModelTestUtils.checkOutcome(result);
         } catch (Exception e) {
             try {
@@ -107,6 +115,9 @@ public class RunArtemisAmqpSetupTask implements ServerSetupTask {
     public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
         try {
             ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(AMQP_PORT_PATH));
+            managementClient.getControllerClient().execute(op);
+
+            op = Util.createRemoveOperation(PathAddress.pathAddress(AMQP_HOST_PATH));
             managementClient.getControllerClient().execute(op);
 
             if (container != null) {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/RunKafkaSetupTask.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/RunKafkaSetupTask.java
@@ -5,6 +5,9 @@
 
 package org.wildfly.test.integration.microprofile.reactive;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -15,11 +18,19 @@ import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.dmr.ModelNode;
 import org.testcontainers.kafka.KafkaContainer;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 @DockerRequired
 public class RunKafkaSetupTask implements ServerSetupTask {
+
+    private static final PathElement BOOTSTRAP_SERVERS_PATH = PathElement.pathElement(SYSTEM_PROPERTY, "calculated.bootstrap.servers");
+
     volatile KafkaContainer container;
     volatile KafkaCompanion companion;
 
@@ -38,7 +49,12 @@ public class RunKafkaSetupTask implements ServerSetupTask {
 
         container.start();
 
-        companion = new KafkaCompanion("INTERNAL://localhost:9092");
+        String bootstrapServers = container.getBootstrapServers();
+        ModelNode op = Util.createAddOperation(PathAddress.pathAddress(BOOTSTRAP_SERVERS_PATH), Map.of(VALUE, new ModelNode(bootstrapServers)));
+        ModelNode result =  managementClient.getControllerClient().execute(op);
+        ModelTestUtils.checkOutcome(result);
+
+        companion = new KafkaCompanion("INTERNAL://" + bootstrapServers);
 
         Map<String, Integer> topicsAndPartitions = getTopicsAndPartitions();
         if (topicsAndPartitions == null || topicsAndPartitions.isEmpty()) {
@@ -66,6 +82,9 @@ public class RunKafkaSetupTask implements ServerSetupTask {
                 e.printStackTrace();
             }
         }
+
+        ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(BOOTSTRAP_SERVERS_PATH));
+        managementClient.getControllerClient().execute(op);
     }
 
 

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/AnonymousAmqpTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/AnonymousAmqpTestCase.java
@@ -23,7 +23,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunArtemisAmqpSetupTask;
@@ -34,7 +33,6 @@ import io.restassured.RestAssured;
 @RunAsClient
 @ServerSetup({RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @DockerRequired
-@Ignore
 public class AnonymousAmqpTestCase {
 
     @ArquillianResource

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/SslAmqpWithSslConfiguredGloballyTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/SslAmqpWithSslConfiguredGloballyTestCase.java
@@ -19,7 +19,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.ConfigureElytronSslContextSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
@@ -36,7 +35,6 @@ import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset
 @RunAsClient
 @ServerSetup({SslAmqpWithSslConfiguredGloballyTestCase.RunArtemisSslUsernamePasswordSecuredSetupTask.class, EnableReactiveExtensionsSetupTask.class, ConfigureElytronSslContextSetupTask.class})
 @DockerRequired
-@Ignore
 public class SslAmqpWithSslConfiguredGloballyTestCase {
     @ArquillianResource
     URL url;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/SslAmqpWithSslConfiguredOnConnectorTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/SslAmqpWithSslConfiguredOnConnectorTestCase.java
@@ -19,7 +19,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.ConfigureElytronSslContextSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
@@ -36,7 +35,6 @@ import static org.jboss.as.test.shared.PermissionUtils.createPermissionsXmlAsset
 @RunAsClient
 @ServerSetup({SslAmqpWithSslConfiguredOnConnectorTestCase.RunArtemisSslUsernamePasswordSecuredSetupTask.class, EnableReactiveExtensionsSetupTask.class, ConfigureElytronSslContextSetupTask.class})
 @DockerRequired
-@Ignore
 public class SslAmqpWithSslConfiguredOnConnectorTestCase {
     @ArquillianResource
     URL url;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/microprofile-config-no-ssl.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/microprofile-config-no-ssl.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-amqp-host=localhost
+amqp-host=${calculated.amqp.host}
 amqp-port=${calculated.amqp.port}
 amqp-username=artemis
 amqp-password=artemis

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/microprofile-config-ssl-connector.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/microprofile-config-ssl-connector.properties
@@ -5,6 +5,7 @@
 
 mp.messaging.outgoing.source.connector=smallrye-amqp
 mp.messaging.outgoing.source.wildfly.elytron.ssl.context=kafka-ssl-test
+mp.messaging.outgoing.source.host=${calculated.amqp.host}
 mp.messaging.outgoing.source.port=${calculated.amqp.port}
 mp.messaging.outgoing.source.username=artemis
 mp.messaging.outgoing.source.password=artemis
@@ -13,6 +14,7 @@ mp.messaging.outgoing.source.use-ssl=true
 mp.messaging.incoming.in.connector=smallrye-amqp
 mp.messaging.incoming.in.address=source
 mp.messaging.incoming.in.wildfly.elytron.ssl.context=kafka-ssl-test
+mp.messaging.incoming.in.host=${calculated.amqp.host}
 mp.messaging.incoming.in.port=${calculated.amqp.port}
 mp.messaging.incoming.in.username=artemis
 mp.messaging.incoming.in.password=artemis

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/microprofile-config-ssl-global.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/amqp/microprofile-config-ssl-global.properties
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+amqp-host=${calculated.amqp.host}
 amqp-port=${calculated.amqp.port}
 amqp-username=artemis
 amqp-password=artemis

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/ReactiveMessagingKafkaUserApiTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/ReactiveMessagingKafkaUserApiTestCase.java
@@ -35,7 +35,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
@@ -46,7 +45,6 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunWith(Arquillian.class)
 @ServerSetup({ReactiveMessagingKafkaUserApiTestCase.CustomRunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @DockerRequired
-@Ignore
 public class ReactiveMessagingKafkaUserApiTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(15000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/api/microprofile-config.properties
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
+
 ##########################################################################################
 # Config for InDepthMetadataBean
 mp.messaging.outgoing.to-kafka1.connector=smallrye-kafka

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/ReactiveMessagingKafkaCompressionTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/ReactiveMessagingKafkaCompressionTestCase.java
@@ -18,7 +18,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
@@ -38,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @DockerRequired
-@Ignore
 public class ReactiveMessagingKafkaCompressionTestCase {
 
     // Downstream we want to disable Snappy on Windows and Mac

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/ReactiveMessagingKafkaWithSnappyFailsOnWindowsAndMacTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/ReactiveMessagingKafkaWithSnappyFailsOnWindowsAndMacTestCase.java
@@ -23,7 +23,6 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
@@ -34,7 +33,6 @@ import java.io.File;
 @RunAsClient
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @DockerRequired
-@Ignore
 public class ReactiveMessagingKafkaWithSnappyFailsOnWindowsAndMacTestCase extends AbstractCliTestBase {
     @ArquillianResource
     public ManagementClient managementClient;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/microprofile-config-no-snappy.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/microprofile-config-no-snappy.properties
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
+
 # Configure the gzip producer
 mp.messaging.outgoing.to-kafka-gzip.connector=smallrye-kafka
 mp.messaging.outgoing.to-kafka-gzip.topic=testing

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/compression/microprofile-config.properties
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
+
 # Configure the gzip producer
 mp.messaging.outgoing.to-kafka-gzip.connector=smallrye-kafka
 mp.messaging.outgoing.to-kafka-gzip.topic=testing

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/serializer/ReactiveMessagingKafkaSerializerTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/serializer/ReactiveMessagingKafkaSerializerTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
@@ -38,7 +37,6 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @DockerRequired
-@Ignore
 public class ReactiveMessagingKafkaSerializerTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(15000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/serializer/microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/serializer/microprofile-config.properties
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
+
 # Configure the Kafka sink (we write to it)
 mp.messaging.outgoing.to-kafka.connector=smallrye-kafka
 mp.messaging.outgoing.to-kafka.topic=testing

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslConfiguredGloballyTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslConfiguredGloballyTestCase.java
@@ -26,7 +26,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.ConfigureElytronSslContextSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
@@ -37,7 +36,6 @@ import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensio
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaWithSslSetupTask.class, EnableReactiveExtensionsSetupTask.class, ConfigureElytronSslContextSetupTask.class})
 @DockerRequired
-@Ignore
 public class ReactiveMessagingKafkaSslConfiguredGloballyTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(15000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslConfiguredOnConnectionTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/ReactiveMessagingKafkaSslConfiguredOnConnectionTestCase.java
@@ -26,7 +26,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.ConfigureElytronSslContextSetupTask;
@@ -37,7 +36,6 @@ import org.wildfly.test.integration.microprofile.reactive.ConfigureElytronSslCon
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaWithSslSetupTask.class, EnableReactiveExtensionsSetupTask.class, ConfigureElytronSslContextSetupTask.class})
 @DockerRequired
-@Ignore
 public class ReactiveMessagingKafkaSslConfiguredOnConnectionTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(15000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/RunKafkaWithSslSetupTask.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/RunKafkaWithSslSetupTask.java
@@ -5,20 +5,35 @@
 
 package org.wildfly.test.integration.microprofile.reactive.messaging.kafka.ssl;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.wildfly.test.integration.microprofile.reactive.KeystoreUtil.SERVER_KEYSTORE_PATH;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.nio.file.Path;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 import io.smallrye.reactive.messaging.kafka.companion.KafkaCompanion;
 import org.jboss.arquillian.testcontainers.api.DockerRequired;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.dmr.ModelNode;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.MountableFile;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.test.integration.microprofile.reactive.KeystoreUtil;
@@ -28,13 +43,18 @@ import org.wildfly.test.integration.microprofile.reactive.KeystoreUtil;
  */
 @DockerRequired
 public class RunKafkaWithSslSetupTask implements ServerSetupTask {
+
+    private static final PathElement BOOTSTRAP_SERVERS_PATH = PathElement.pathElement(SYSTEM_PROPERTY, "calculated.bootstrap.servers");
+    private static final String DOCKER_HOST_PLACEHOLDER = "$DOCKER_HOST";
+
     volatile GenericContainer container;
     volatile KafkaCompanion companion;
 
     @Override
     public void setup(ManagementClient managementClient, String s) throws Exception {
         try {
-            KeystoreUtil.createKeystores();
+            String dockerHost = DockerClientFactory.instance().dockerHostIpAddress();
+            KeystoreUtil.createKeystores(dockerHost);
             String kafkaVersion = WildFlySecurityManager.getPropertyPrivileged("wildfly.test.kafka.version", null);
             if (kafkaVersion == null) {
                 throw new IllegalArgumentException("Specify Kafka version with -Dwildfly.test.kafka.version");
@@ -43,8 +63,8 @@ public class RunKafkaWithSslSetupTask implements ServerSetupTask {
             // The KafkaContainer class doesn't play nicely when trying to make it use SSL
             container = new GenericContainer("apache/kafka-native:" + kafkaVersion);
             container.setPortBindings(Arrays.asList("9092:9092", "19092:19092"));
-            container.withCopyFileToContainer(
-                    MountableFile.forHostPath(Path.of("src/test/resources/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/server.properties")),
+            container.withCopyToContainer(
+                    getKafkaServerProperties(dockerHost),
                     "/mnt/shared/config/server.properties"
             );
             container.waitingFor(Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1));
@@ -60,20 +80,25 @@ public class RunKafkaWithSslSetupTask implements ServerSetupTask {
 
             container.start();
 
-            companion = new KafkaCompanion("INTERNAL://localhost:19092");
+            String bootstrapServers = String.format("%s:%s", container.getHost(), container.getMappedPort(9092));
+            ModelNode op = Util.createAddOperation(PathAddress.pathAddress(BOOTSTRAP_SERVERS_PATH), Map.of(VALUE, new ModelNode(bootstrapServers)));
+            ModelNode result =  managementClient.getControllerClient().execute(op);
+            ModelTestUtils.checkOutcome(result);
+
+            companion = new KafkaCompanion("INTERNAL://" + container.getHost() + ":19092");
             companion.topics().createAndWait("testing", 1, Duration.of(10, ChronoUnit.SECONDS));
         } catch (Exception e) {
-            cleanupKafka();
+            cleanupKafka(managementClient);
             throw e;
         }
     }
 
     @Override
     public void tearDown(ManagementClient managementClient, String s) throws Exception {
-        cleanupKafka();
+        cleanupKafka(managementClient);
     }
 
-    private void cleanupKafka() throws IOException {
+    private void cleanupKafka(ManagementClient managementClient) throws IOException {
         try {
             if (companion != null) {
                 try {
@@ -89,8 +114,19 @@ public class RunKafkaWithSslSetupTask implements ServerSetupTask {
                     e.printStackTrace();
                 }
             }
+            ModelNode op = Util.createRemoveOperation(PathAddress.pathAddress(BOOTSTRAP_SERVERS_PATH));
+            managementClient.getControllerClient().execute(op);
         } finally {
             KeystoreUtil.cleanUp();
         }
     }
+
+    private Transferable getKafkaServerProperties(String dockerHost) {
+        InputStream inputStream = Objects.requireNonNull(RunKafkaWithSslSetupTask.class.getResourceAsStream("server.properties"));
+        String serverProperties = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)).lines()
+                .collect(Collectors.joining("\n"));
+        String resolvedServerProperties = serverProperties.replace(DOCKER_HOST_PLACEHOLDER, dockerHost);
+        return Transferable.of(resolvedServerProperties);
+    }
+
 }

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/microprofile-config-ssl-connection.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/microprofile-config-ssl-connection.properties
@@ -4,7 +4,7 @@
 #
 
 # 9092 is secured with SSL as per ReactiveMessagingKafkaSslTestCase
-bootstrap.servers=[localhost:9092]
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
 
 # Configure the Kafka sink (we write to it)
 mp.messaging.outgoing.to-kafka.connector=smallrye-kafka

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/microprofile-config-ssl-global.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/microprofile-config-ssl-global.properties
@@ -4,7 +4,7 @@
 #
 
 # 9092 is secured with SSL as per ReactiveMessagingKafkaSslTestCase
-bootstrap.servers=[localhost:9092]
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
 mp.messaging.connector.smallrye-kafka.wildfly.elytron.ssl.context=kafka-ssl-test
 
 # Configure the Kafka sink (we write to it)

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/ReactiveMessagingKafkaTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/ReactiveMessagingKafkaTestCase.java
@@ -27,7 +27,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
@@ -38,7 +37,6 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunWith(Arquillian.class)
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @DockerRequired
-@Ignore
 public class ReactiveMessagingKafkaTestCase {
 
     private static final long TIMEOUT = TimeoutUtil.adjust(25000);

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/tx/microprofile-config.properties
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
+
 # Configure the Kafka sink (we write to it)
 mp.messaging.outgoing.to-kafka.connector=smallrye-kafka
 mp.messaging.outgoing.to-kafka.topic=testing

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/MultiDeploymentReactiveMessagingTestCase.java
@@ -45,7 +45,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunArtemisAmqpSetupTask;
@@ -62,7 +61,6 @@ import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.dep
 @RunAsClient
 @ServerSetup({RunKafkaSetupTask.class, RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @DockerRequired
-@Ignore
 public class MultiDeploymentReactiveMessagingTestCase extends AbstractCliTestBase {
 
     private static final String BASE_NAME = "multideployment-rm";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/amqp/microprofile-config.properties
@@ -2,6 +2,8 @@
 # Copyright The WildFly Authors
 # SPDX-License-Identifier: Apache-2.0
 #
+
+amqp-host=${calculated.amqp.host}
 amqp-port=${calculated.amqp.port}
 
 mp.messaging.outgoing.source.connector=smallrye-amqp

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/deployment/kafka/microprofile-config.properties
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
+
 mp.messaging.outgoing.source.connector=smallrye-kafka
 mp.messaging.outgoing.source.topic=testing
 mp.messaging.outgoing.source.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/MultiEarModuleReactiveMessagingTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/MultiEarModuleReactiveMessagingTestCase.java
@@ -39,7 +39,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunArtemisAmqpSetupTask;
@@ -57,7 +56,6 @@ import org.wildfly.test.integration.microprofile.reactive.messaging.multiple.ear
 @RunAsClient
 @ServerSetup({RunKafkaSetupTask.class, RunArtemisAmqpSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @DockerRequired
-@Ignore
 public class MultiEarModuleReactiveMessagingTestCase {
 
     private static final String BASE_NAME = "multimodule-rm";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/amqp/microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/amqp/microprofile-config.properties
@@ -2,6 +2,8 @@
 # Copyright The WildFly Authors
 # SPDX-License-Identifier: Apache-2.0
 #
+
+amqp-host=${calculated.amqp.host}
 amqp-port=${calculated.amqp.port}
 
 mp.messaging.outgoing.amqp.connector=smallrye-amqp

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/kafka/microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/multiple/earmodule/kafka/microprofile-config.properties
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
+
 mp.messaging.outgoing.kafka.connector=smallrye-kafka
 mp.messaging.outgoing.kafka.topic=testing
 mp.messaging.outgoing.kafka.value.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/AmqpReactiveMessagingAndOtelTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/AmqpReactiveMessagingAndOtelTestCase.java
@@ -15,7 +15,6 @@ import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorC
 import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
-import org.junit.Ignore;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunArtemisAmqpSetupTask;
 
@@ -24,7 +23,6 @@ import org.wildfly.test.integration.microprofile.reactive.RunArtemisAmqpSetupTas
 @RunAsClient
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class, EnableReactiveExtensionsSetupTask.class, RunArtemisAmqpSetupTask.class})
 @DockerRequired
-@Ignore
 public class AmqpReactiveMessagingAndOtelTestCase extends BaseReactiveMessagingAndOtelTest {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollector;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/KafkaReactiveMessagingAndOtelTestCase.java
@@ -15,7 +15,6 @@ import org.jboss.as.test.shared.observability.containers.OpenTelemetryCollectorC
 import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollectorSetupTask;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
-import org.junit.Ignore;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 
@@ -24,7 +23,6 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunAsClient
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class, EnableReactiveExtensionsSetupTask.class, RunKafkaSetupTask.class})
 @DockerRequired
-@Ignore
 public class KafkaReactiveMessagingAndOtelTestCase extends BaseReactiveMessagingAndOtelTest {
     @Testcontainer
     private OpenTelemetryCollectorContainer otelCollector;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/application/amqp-microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/application/amqp-microprofile-config.properties
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-amqp-host=localhost
+amqp-host=${calculated.amqp.host}
 amqp-port=${calculated.amqp.port}
 amqp-username=artemis
 amqp-password=artemis

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/application/kafka-microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/otel/application/kafka-microprofile-config.properties
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
+
 # Needed to turn on MP Telemetry
 otel.sdk.disabled=false
 

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/ReactiveMessagingChannelsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/ReactiveMessagingChannelsTestCase.java
@@ -38,7 +38,6 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.microprofile.reactive.EnableReactiveExtensionsSetupTask;
 import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
@@ -50,7 +49,6 @@ import org.wildfly.test.integration.microprofile.reactive.RunKafkaSetupTask;
 @RunAsClient
 @ServerSetup({RunKafkaSetupTask.class, EnableReactiveExtensionsSetupTask.class})
 @DockerRequired
-@Ignore
 public class ReactiveMessagingChannelsTestCase {
     @ArquillianResource
     URL url;

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/microprofile-config.properties
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/microprofile/reactive/messaging/rest/channels/microprofile-config.properties
@@ -3,6 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+mp.messaging.connector.smallrye-kafka.bootstrap.servers=${calculated.bootstrap.servers}
+
 # Configure the Kafka sink (we write to it)
 mp.messaging.outgoing.to-kafka.connector=smallrye-kafka
 mp.messaging.outgoing.to-kafka.topic=testing

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/MicrometerOtelIntegrationTestCase.java
@@ -32,7 +32,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.wildfly.test.integration.observability.JaxRsActivator;
 
@@ -40,7 +39,6 @@ import org.wildfly.test.integration.observability.JaxRsActivator;
 @ServerSetup(MicrometerSetupTask.class)
 @DockerRequired
 @RunAsClient
-@Ignore
 public class MicrometerOtelIntegrationTestCase {
     public static final int REQUEST_COUNT = 5;
     public static final String DEPLOYMENT_NAME = "micrometer-test.war";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/EarDeploymentTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/EarDeploymentTestCase.java
@@ -17,7 +17,6 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource1;
 import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource2;
 import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
@@ -50,7 +49,6 @@ public class EarDeploymentTestCase extends BaseMultipleTestCase {
     }
 
     @Test
-    @Ignore
     public void dataTest(@ArquillianResource @OperateOnDeployment(ENTERPRISE_APP) URL earUrl)
             throws URISyntaxException, InterruptedException {
         makeRequests(new URI(String.format("%s/%s/%s/%s", earUrl, ENTERPRISE_APP, SERVICE_ONE, DuplicateMetricResource1.TAG)));

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MultipleWarTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/micrometer/multiple/MultipleWarTestCase.java
@@ -20,7 +20,6 @@ import org.jboss.as.test.shared.observability.signals.PrometheusMetric;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.wildfly.test.integration.observability.JaxRsActivator;
 import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource1;
 import org.wildfly.test.integration.observability.micrometer.multiple.application.DuplicateMetricResource2;
@@ -43,7 +42,6 @@ public class MultipleWarTestCase extends BaseMultipleTestCase {
 
     @Test
     @InSequence(1)
-    @Ignore
     public void checkPingCount(@ArquillianResource @OperateOnDeployment(SERVICE_ONE) URL serviceOne,
                                @ArquillianResource @OperateOnDeployment(SERVICE_TWO) URL serviceTwo)
             throws URISyntaxException, InterruptedException {

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/ContextPropagationTestCase.java
@@ -23,7 +23,6 @@ import org.jboss.as.test.shared.observability.signals.jaeger.JaegerTrace;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.wildfly.test.integration.observability.opentelemetry.application.OtelService2;
 
 /**
@@ -34,7 +33,6 @@ import org.wildfly.test.integration.observability.opentelemetry.application.Otel
 @RunAsClient
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
 @DockerRequired
-@Ignore
 public class ContextPropagationTestCase extends BaseOpenTelemetryTest {
 
     private static final String DEPLOYMENT_SERVICE1 = "service1";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryIntegrationTestCase.java
@@ -17,13 +17,11 @@ import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollec
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.wildfly.test.integration.observability.setuptask.ServiceNameSetupTask;
 
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class, ServiceNameSetupTask.class})
 @RunAsClient
 @DockerRequired
-@Ignore
 public class OpenTelemetryIntegrationTestCase extends BaseOpenTelemetryTest {
     private static final String DEPLOYMENT_NAME = "otelinteg";
 

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/OpenTelemetryMetricsTestCase.java
@@ -21,12 +21,10 @@ import org.jboss.as.test.shared.observability.setuptasks.OpenTelemetryWithCollec
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.wildfly.test.integration.observability.opentelemetry.application.OtelMetricResource;
 
 @ServerSetup(OpenTelemetryWithCollectorSetupTask.class)
 @RunAsClient
-@Ignore
 public class OpenTelemetryMetricsTestCase extends BaseOpenTelemetryTest {
     private static final int REQUEST_COUNT = 5;
     private static final String DEPLOYMENT_NAME = "otel-metrics-test";

--- a/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/WithSpanTestCase.java
+++ b/testsuite/integration/expansion/src/test/java/org/wildfly/test/integration/observability/opentelemetry/WithSpanTestCase.java
@@ -21,13 +21,11 @@ import org.jboss.as.test.shared.observability.signals.jaeger.JaegerSpan;
 import org.jboss.shrinkwrap.api.Archive;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.wildfly.test.integration.observability.opentelemetry.span.AppScopedBean;
 
 @RunAsClient
 @ServerSetup({OpenTelemetryWithCollectorSetupTask.class})
 @DockerRequired
-@Ignore
 public class WithSpanTestCase extends BaseOpenTelemetryTest {
     private static final String DEPLOYMENT_NAME = "with-span-test";
 

--- a/testsuite/integration/expansion/src/test/resources/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/server.properties
+++ b/testsuite/integration/expansion/src/test/resources/org/wildfly/test/integration/microprofile/reactive/messaging/kafka/ssl/server.properties
@@ -1,4 +1,4 @@
-advertised.listeners=SSL://localhost:9092,INTERNAL://localhost:19092
+advertised.listeners=SSL://$DOCKER_HOST:9092,INTERNAL://$DOCKER_HOST:19092
 controller.listener.names=CONTROLLER
 group.initial.rebalance.delay.ms=0
 inter.broker.listener.name=INTERNAL

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/JaegerContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/JaegerContainer.java
@@ -45,6 +45,6 @@ class JaegerContainer extends BaseContainer<JaegerContainer> {
     }
 
     private String getJaegerEndpoint() {
-        return "http://localhost:" + getMappedPort(PORT_JAEGER_QUERY);
+        return "http://" + getHost() + ":" + getMappedPort(PORT_JAEGER_QUERY);
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/observability/containers/OpenTelemetryCollectorContainer.java
@@ -75,15 +75,15 @@ public class OpenTelemetryCollectorContainer extends BaseContainer<OpenTelemetry
     }
 
     public String getOtlpGrpcEndpoint() {
-        return "http://localhost:" + getMappedPort(OTLP_GRPC_PORT);
+        return "http://" +  getHost() + ":" + getMappedPort(OTLP_GRPC_PORT);
     }
 
     public String getOtlpHttpEndpoint() {
-        return "http://localhost:" + getMappedPort(OTLP_HTTP_PORT);
+        return "http://" +  getHost() + ":" + getMappedPort(OTLP_HTTP_PORT);
     }
 
     public String getPrometheusUrl() {
-        return "http://localhost:" + getMappedPort(PROMETHEUS_PORT) + "/metrics";
+        return "http://" +  getHost() + ":" + getMappedPort(PROMETHEUS_PORT) + "/metrics";
     }
 
     public List<JaegerTrace> getTraces(String serviceName) throws InterruptedException {

--- a/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
+++ b/testsuite/shared/src/main/java/org/wildfly/test/distribution/validation/ProvisioningConsistencyBaseTest.java
@@ -28,7 +28,6 @@ import org.jboss.logging.Logger;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.Ignore;
 
 /**
  * Validates that provisioning using wildfly-maven-plugin and the channel manifest produced by
@@ -85,7 +84,6 @@ public abstract class ProvisioningConsistencyBaseTest {
      */
     @SuppressWarnings("JUnit3StyleTestMethodInJUnit4Class")
     @Test
-    @Ignore
     public void testInstallationEquivalence() throws IOException {
         final AtomicReference<Path> installationMetadata = new AtomicReference<>();
         final List<String> errors = new ArrayList<>();


### PR DESCRIPTION
Problem with WildFly container-based tests were that they assumed that docker host is available on localhost.
This is not the case on PSI environment where Jenkins nodes themselves are docker containers. Adjustments to
existing tests were made to be able to execute them in a Docker-in-Docker CI environment.