### PR TITLE
PJFCB-21925 [HIGH] GHSA-72hv-8253-57qq WildFly 36, ### Summary The no…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,7 @@
         <version.antlr>4.13.0</version.antlr>
         <version.com.carrotsearch.hppc>0.10.0</version.com.carrotsearch.hppc>
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.18.3</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.18.6</version.com.fasterxml.jackson>
         <version.com.fasterxml.jackson.databind>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.databind>
         <version.com.fasterxml.jackson.jr.jackson-jr-objects>${version.com.fasterxml.jackson}</version.com.fasterxml.jackson.jr.jackson-jr-objects>
         <version.com.github.ben-manes.caffeine>3.2.0</version.com.github.ben-manes.caffeine>


### PR DESCRIPTION
…n-blocking (async) JSON parser in `jackson-core` bypasses the `maxNumberLength` constraint (default: 1000 characters) defined in `StreamReadConstraints`

Thanks for submitting your Pull Request!
Please delete this text.
Remember to use the Jira issue ID in the PR title, and any commits.
